### PR TITLE
Packaging PR1: legal docs + in-app links (no runtime changes)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,14 @@
+# Install / Run
+
+## Requirements
+- Node 18+, npm 9+
+- macOS/Windows/Linux
+
+## Commands
+```
+npm ci
+npm run dev           # local
+npm run build         # production build → dist/
+npm run preview       # serve dist locally
+npm run verify:release  # typecheck + tests + build
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Copyright (c) 2025 Zack (Zcg321). All rights reserved.
+
+This software is proprietary and confidential. No license is granted to copy, modify, distribute, or create derivative works without explicit written permission.
+
+This repository may include open-source dependencies governed by their respective licenses.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,1 @@
+This product bundles open-source software. See node_modules for license texts of dependencies.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,8 @@
+# Alchohalt Privacy
+
+- 100% on-device by design. No accounts, no cloud sync, no analytics.
+- Optional notifications are scheduled locally by the device.
+- Export/Import moves your data as JSON between your devices; you control where it goes.
+- If future online features are added, they will be *opt-in*, with clear disclosures and an updated policy.
+
+Contact: privacy@placeholder.local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+- No inbound services; app is offline-first.
+- Report vulnerabilities to: security@placeholder.local
+- Please do not publicly disclose before we coordinate a fix.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,9 @@
+# Terms of Use (Draft)
+
+Alchohalt is a self-tracking tool. It provides *no medical advice*.
+By using the app you agree to:
+- Use at your own risk; no warranties.
+- Follow local laws/regulations.
+- Not attempt to reverse engineer or redistribute without permission.
+
+Contact: legal@placeholder.local

--- a/public/docs/NOTICE.md
+++ b/public/docs/NOTICE.md
@@ -1,0 +1,1 @@
+This product bundles open-source software. See node_modules for license texts of dependencies.

--- a/public/docs/PRIVACY.md
+++ b/public/docs/PRIVACY.md
@@ -1,0 +1,8 @@
+# Alchohalt Privacy
+
+- 100% on-device by design. No accounts, no cloud sync, no analytics.
+- Optional notifications are scheduled locally by the device.
+- Export/Import moves your data as JSON between your devices; you control where it goes.
+- If future online features are added, they will be *opt-in*, with clear disclosures and an updated policy.
+
+Contact: privacy@placeholder.local

--- a/public/docs/SECURITY.md
+++ b/public/docs/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+- No inbound services; app is offline-first.
+- Report vulnerabilities to: security@placeholder.local
+- Please do not publicly disclose before we coordinate a fix.

--- a/public/docs/TERMS.md
+++ b/public/docs/TERMS.md
@@ -1,0 +1,9 @@
+# Terms of Use (Draft)
+
+Alchohalt is a self-tracking tool. It provides *no medical advice*.
+By using the app you agree to:
+- Use at your own risk; no warranties.
+- Follow local laws/regulations.
+- Not attempt to reverse engineer or redistribute without permission.
+
+Contact: legal@placeholder.local

--- a/src/features/settings/LegalLinks.tsx
+++ b/src/features/settings/LegalLinks.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function LegalLinks(){
+  return (
+    <section className="p-4 mt-4 border rounded-2xl">
+      <h2 className="font-semibold mb-2">Legal</h2>
+      <ul className="list-disc pl-5 text-sm">
+        <li><a className="underline" href="/docs/PRIVACY.md" target="_blank" rel="noreferrer">Privacy</a></li>
+        <li><a className="underline" href="/docs/TERMS.md" target="_blank" rel="noreferrer">Terms</a></li>
+        <li><a className="underline" href="/docs/SECURITY.md" target="_blank" rel="noreferrer">Security</a></li>
+      </ul>
+      <p className="text-xs opacity-60 mt-2">Alchohalt keeps data on-device and provides no medical advice.</p>
+    </section>
+  );
+}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -4,6 +4,8 @@ import type { Theme, Language } from '../../store/db';
 import { resyncNotifications } from '../../lib/notify';
 import DevTools from './DevTools';
 import ExportImport from '../drinks/ExportImport';
+
+import LegalLinks from './LegalLinks';
 import About from './About';
 
 export default function SettingsPanel() {
@@ -60,9 +62,10 @@ export default function SettingsPanel() {
         </p>
         <ExportImport />
       </section>
+      <About />
+      <LegalLinks />
+      <DevTools />
+    </div>
+  );
+}
 
-        <About />
-        <DevTools />
-      </div>
-    );
-  }


### PR DESCRIPTION
## Summary
This pull request adds legal and consumer documentation and in-app links without changing runtime behavior.

### Changes
- Added proprietary LICENSE, PRIVACY.md, TERMS.md, SECURITY.md, NOTICE.md, and INSTALL.md in the repository root.
- Created LegalLinks.tsx component and imported it into SettingsPanel to display links to Privacy, Terms, and Security documents.
- Copied PRIVACY.md, TERMS.md, SECURITY.md and NOTICE.md into the public/docs directory for PWA offline access.
- Updated the settings UI to include the LegalLinks section.

## Checks
- [ ] `npm ci && npm run verify:release` passes locally
- [ ] No runtime behavior change
- [ ] Legal documents render correctly via `/docs/*` routes
