### PR TITLE
Fix skip link target and localization

### DIFF
--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -53,7 +53,7 @@ export default function MainContent({
   const { t } = useLanguage();
 
   return (
-    <main className="container mx-auto px-4 py-6 space-y-8 max-w-4xl">
+    <main id="main" className="container mx-auto px-4 py-6 space-y-8 max-w-4xl">
       <ReminderBanner />
       
       {/* Personalized Dashboard - New Feature */}

--- a/src/components/A11ySkipLink.tsx
+++ b/src/components/A11ySkipLink.tsx
@@ -1,4 +1,15 @@
 import React from 'react';
-export default function A11ySkipLink(){
-  return <a href="#main" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 bg-black text-white px-3 py-1 rounded">Skip to content</a>;
+import { useLanguage } from '../i18n';
+
+export default function A11ySkipLink() {
+  const { t } = useLanguage();
+
+  return (
+    <a
+      href="#main"
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 bg-black text-white px-3 py-1 rounded"
+    >
+      {t('skipToContent')}
+    </a>
+  );
 }


### PR DESCRIPTION
## Summary
- add an id to the main content container so the skip link has a valid target
- localize the accessibility skip link label via the existing language context

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68daf3f4f0488325b1825f7a59e74590