### PR TITLE
Use drinkDeleted translation for undo toast

### DIFF
--- a/src/app/MainContent.tsx
+++ b/src/app/MainContent.tsx
@@ -214,7 +214,7 @@ export default function MainContent({
       {/* Undo Toast */}
       {lastDeleted && (
         <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-6 py-3 rounded-lg shadow-lg flex items-center gap-3 z-50 animate-slide-up">
-          <span className="text-sm">{t('deletedDrink')}</span>
+          <span className="text-sm">{t('drinkDeleted')}</span>
           <Button
             variant="ghost"
             size="sm"


### PR DESCRIPTION
## Summary
- switch the undo toast in MainContent to reuse the existing `drinkDeleted` translation key
- verified the `drinkDeleted` entries are present in the English and Spanish locale files

## Testing
- npx vitest run src/app/__tests__/MainContent.smoke.test.tsx
- npx vitest run src/app/__tests__/MainContent.toast.test.tsx


------
https://chatgpt.com/codex/tasks/task_b_68daf3f4ff4c83258513d581bc103258