### PR TITLE
Localize insights UI strings and add translation smoke test

### DIFF
--- a/src/features/insights/ProgressVisualization.tsx
+++ b/src/features/insights/ProgressVisualization.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import type { Drink } from '../drinks/DrinkForm';
 import type { Goals } from '../../types/common';
 import { stdDrinks } from '../../lib/calc';
+import { useLanguage } from '../../i18n';
 
 interface Props {
   drinks: Drink[];
@@ -29,6 +30,7 @@ interface ProgressData {
 }
 
 export default function ProgressVisualization({ drinks, goals }: Props) {
+  const { t } = useLanguage();
 
   const progressData = useMemo((): ProgressData => {
     const now = Date.now();
@@ -92,13 +94,13 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
       {/* Daily & Weekly Progress */}
       <div className="card">
         <div className="card-header">
-          <h2 className="text-xl font-semibold">Goal Progress</h2>
+          <h2 className="text-xl font-semibold">{t('progressVisualization.goalProgress')}</h2>
         </div>
         <div className="card-content space-y-6">
           {/* Daily Progress */}
           <div>
             <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium">Daily Limit</span>
+              <span className="text-sm font-medium">{t('progressVisualization.dailyLimit')}</span>
               <span className="text-sm text-neutral-600 dark:text-neutral-400">
                 {progressData.dailyProgress.toFixed(0)}%
               </span>
@@ -116,9 +118,13 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
               />
             </div>
             <div className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              {progressData.dailyProgress <= 100 
-                ? `${(goals.dailyCap - (goals.dailyCap * progressData.dailyProgress / 100)).toFixed(1)} drinks remaining`
-                : `Exceeded by ${(progressData.dailyProgress - 100).toFixed(0)}%`
+              {progressData.dailyProgress <= 100
+                ? t('progressVisualization.dailyRemaining', {
+                    count: (goals.dailyCap - (goals.dailyCap * progressData.dailyProgress / 100)).toFixed(1)
+                  })
+                : t('progressVisualization.dailyExceeded', {
+                    percent: (progressData.dailyProgress - 100).toFixed(0)
+                  })
               }
             </div>
           </div>
@@ -126,7 +132,7 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
           {/* Weekly Progress */}
           <div>
             <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium">Weekly Goal</span>
+              <span className="text-sm font-medium">{t('progressVisualization.weeklyGoal')}</span>
               <span className="text-sm text-neutral-600 dark:text-neutral-400">
                 {progressData.weeklyProgress.toFixed(0)}%
               </span>
@@ -144,9 +150,13 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
               />
             </div>
             <div className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
-              {progressData.weeklyProgress <= 100 
-                ? `${(goals.weeklyGoal - (goals.weeklyGoal * progressData.weeklyProgress / 100)).toFixed(1)} drinks remaining this week`
-                : `Exceeded by ${(progressData.weeklyProgress - 100).toFixed(0)}%`
+              {progressData.weeklyProgress <= 100
+                ? t('progressVisualization.weeklyRemaining', {
+                    count: (goals.weeklyGoal - (goals.weeklyGoal * progressData.weeklyProgress / 100)).toFixed(1)
+                  })
+                : t('progressVisualization.weeklyExceeded', {
+                    percent: (progressData.weeklyProgress - 100).toFixed(0)
+                  })
               }
             </div>
           </div>
@@ -156,7 +166,7 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
       {/* Streak Milestone */}
       <div className="card">
         <div className="card-header">
-          <h2 className="text-xl font-semibold">Streak Milestone</h2>
+          <h2 className="text-xl font-semibold">{t('progressVisualization.streakMilestone')}</h2>
         </div>
         <div className="card-content">
           <div className="text-center mb-4">
@@ -164,13 +174,17 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
               {progressData.streakMilestones.current}
             </div>
             <div className="text-sm text-neutral-600 dark:text-neutral-400">
-              Days alcohol-free
+              {t('progressVisualization.daysAlcoholFree')}
             </div>
           </div>
-          
+
           <div className="mb-2">
             <div className="flex justify-between items-center mb-2">
-              <span className="text-sm">Next milestone: {progressData.streakMilestones.next} days</span>
+              <span className="text-sm">
+                {t('progressVisualization.nextMilestone', {
+                  days: progressData.streakMilestones.next
+                })}
+              </span>
               <span className="text-sm text-neutral-600 dark:text-neutral-400">
                 {Math.round(progressData.streakMilestones.progress)}%
               </span>
@@ -182,9 +196,11 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
               />
             </div>
           </div>
-          
+
           <div className="text-xs text-center text-neutral-500 dark:text-neutral-400">
-            {progressData.streakMilestones.next - progressData.streakMilestones.current} days to go!
+            {t('progressVisualization.daysToGo', {
+              count: progressData.streakMilestones.next - progressData.streakMilestones.current
+            })}
           </div>
         </div>
       </div>
@@ -192,7 +208,7 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
       {/* Spending Analysis */}
       <div className="card">
         <div className="card-header">
-          <h2 className="text-xl font-semibold">Monthly Spending</h2>
+          <h2 className="text-xl font-semibold">{t('progressVisualization.monthlySpending')}</h2>
         </div>
         <div className="card-content">
           <div className="grid grid-cols-2 gap-4 mb-4">
@@ -201,7 +217,7 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
                 ${progressData.monthlySpending.actual.toFixed(0)}
               </div>
               <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                Spent this month
+                {t('progressVisualization.spentThisMonth')}
               </div>
             </div>
             <div className="text-center">
@@ -209,14 +225,14 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
                 ${progressData.monthlySpending.savings.toFixed(0)}
               </div>
               <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                Potential savings
+                {t('progressVisualization.potentialSavings')}
               </div>
             </div>
           </div>
-          
+
           <div className="relative">
             <div className="flex justify-between items-center mb-2">
-              <span className="text-sm">Budget usage</span>
+              <span className="text-sm">{t('progressVisualization.budgetUsage')}</span>
               <span className="text-sm text-neutral-600 dark:text-neutral-400">
                 {((progressData.monthlySpending.actual / progressData.monthlySpending.budget) * 100).toFixed(0)}%
               </span>
@@ -242,7 +258,7 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
       {/* Health Metrics */}
       <div className="card">
         <div className="card-header">
-          <h2 className="text-xl font-semibold">Health Insights</h2>
+          <h2 className="text-xl font-semibold">{t('progressVisualization.healthInsights')}</h2>
         </div>
         <div className="card-content">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -251,32 +267,32 @@ export default function ProgressVisualization({ drinks, goals }: Props) {
                 {progressData.healthMetrics.alcoholFreeDays}
               </div>
               <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                AF days this month
+                {t('progressVisualization.afDaysThisMonth')}
               </div>
             </div>
-            
+
             <div className="text-center">
               <div className="text-2xl font-bold text-purple-600 dark:text-purple-400 mb-1">
                 {progressData.healthMetrics.averageCraving.toFixed(1)}
               </div>
               <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                Avg. craving level
+                {t('progressVisualization.avgCravingLevel')}
               </div>
             </div>
-            
+
             <div className="text-center">
               <div className={`text-2xl font-bold mb-1 ${
-                progressData.healthMetrics.improvementTrend === 'improving' 
+                progressData.healthMetrics.improvementTrend === 'improving'
                   ? 'text-green-600 dark:text-green-400'
                   : progressData.healthMetrics.improvementTrend === 'declining'
                   ? 'text-red-600 dark:text-red-400'
                   : 'text-yellow-600 dark:text-yellow-400'
               }`}>
-                {progressData.healthMetrics.improvementTrend === 'improving' ? '📈' : 
+                {progressData.healthMetrics.improvementTrend === 'improving' ? '📈' :
                  progressData.healthMetrics.improvementTrend === 'declining' ? '📉' : '➡️'}
               </div>
               <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                Overall trend
+                {t('progressVisualization.overallTrend')}
               </div>
             </div>
           </div>

--- a/src/features/insights/QuickActions.tsx
+++ b/src/features/insights/QuickActions.tsx
@@ -29,6 +29,10 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
   
   const currentStreak = getCurrentStreak(drinks);
   const isAlcoholFree = todayStd === 0;
+  const todayProgressLabel = t('quickActions.todayDrinksProgress', {
+    consumed: todayStd.toFixed(1),
+    limit: goals.dailyCap,
+  });
 
   // Quick drink presets
   const quickDrinks = [
@@ -80,7 +84,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
         <div className="card text-center">
           <div className="card-content">
             <div className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
-              {todayStd.toFixed(1)} / {goals.dailyCap}
+              {todayProgressLabel}
             </div>
             <div className="text-sm text-neutral-600 dark:text-neutral-400">
               {t('quickActions.todayDrinksLabel')}

--- a/src/features/insights/QuickActions.tsx
+++ b/src/features/insights/QuickActions.tsx
@@ -6,6 +6,9 @@ import { stdDrinks } from '../../lib/calc';
 import { useAnalytics } from '../analytics/analytics';
 import { getCurrentStreak } from './lib';
 import MoodTracker from '../mood/MoodTracker';
+import { useLanguage, type TranslationValues } from '../../i18n';
+
+type Translator = (key: string, vars?: TranslationValues) => string;
 
 interface Props {
   drinks: Drink[];
@@ -18,6 +21,7 @@ interface Props {
 export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings, onOpenStats }: Props) {
   const [showMoodCheck, setShowMoodCheck] = useState(false);
   const { trackFeatureUsage } = useAnalytics();
+  const { t } = useLanguage();
 
   const todayStart = new Date().setHours(0, 0, 0, 0);
   const todayDrinks = drinks.filter(d => d.ts >= todayStart);
@@ -28,10 +32,10 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
 
   // Quick drink presets
   const quickDrinks = [
-    { name: 'Beer (355ml, 5%)', volumeMl: 355, abvPct: 5.0 },
-    { name: 'Wine (148ml, 12%)', volumeMl: 148, abvPct: 12.0 },
-    { name: 'Cocktail (44ml, 40%)', volumeMl: 44, abvPct: 40.0 },
-    { name: 'Custom Entry', volumeMl: 0, abvPct: 0 },
+    { name: t('quickActions.drinks.beer', { volume: 355, abv: 5 }), volumeMl: 355, abvPct: 5.0 },
+    { name: t('quickActions.drinks.wine', { volume: 148, abv: 12 }), volumeMl: 148, abvPct: 12.0 },
+    { name: t('quickActions.drinks.cocktail', { volume: 44, abv: 40 }), volumeMl: 44, abvPct: 40.0 },
+    { name: t('quickActions.drinks.custom'), volumeMl: 0, abvPct: 0 },
   ];
 
   const handleQuickLog = (preset: typeof quickDrinks[0]) => {
@@ -68,7 +72,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               {currentStreak}
             </div>
             <div className="text-sm text-neutral-600 dark:text-neutral-400">
-              Days alcohol-free
+              {t('quickActions.daysAlcoholFreeLabel')}
             </div>
           </div>
         </div>
@@ -79,7 +83,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               {todayStd.toFixed(1)} / {goals.dailyCap}
             </div>
             <div className="text-sm text-neutral-600 dark:text-neutral-400">
-              Today's drinks
+              {t('quickActions.todayDrinksLabel')}
             </div>
           </div>
         </div>
@@ -88,7 +92,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
       {/* Quick Actions */}
       <div className="card">
         <div className="card-header">
-          <h3 className="font-semibold">Quick Actions</h3>
+          <h3 className="font-semibold">{t('quickActions.title')}</h3>
         </div>
         <div className="card-content">
           <div className="grid grid-cols-2 gap-3">
@@ -99,7 +103,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               onClick={handleMoodCheckIn}
               leftIcon={<HeartIcon />}
             >
-              Mood Check-In
+              {t('quickActions.actions.moodCheckIn')}
             </Button>
             
             <Button
@@ -109,7 +113,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               onClick={onOpenStats}
               leftIcon={<ChartIcon />}
             >
-              View Progress
+              {t('quickActions.actions.viewProgress')}
             </Button>
             
             <Button
@@ -119,7 +123,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               onClick={onOpenSettings}
               leftIcon={<SettingsIcon />}
             >
-              Settings
+              {t('quickActions.actions.settings')}
             </Button>
             
             <Button
@@ -128,7 +132,7 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
               className="h-12"
               leftIcon={isAlcoholFree ? <CheckIcon /> : <CalendarIcon />}
             >
-              {isAlcoholFree ? 'AF Today!' : 'Log Drink'}
+              {isAlcoholFree ? t('quickActions.actions.afToday') : t('quickActions.actions.logDrink')}
             </Button>
           </div>
         </div>
@@ -137,9 +141,9 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
       {/* Quick Drink Logging */}
       <div className="card">
         <div className="card-header">
-          <h3 className="font-semibold">Quick Log</h3>
+          <h3 className="font-semibold">{t('quickActions.quickLog.title')}</h3>
           <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            Tap to log common drinks
+            {t('quickActions.quickLog.subtitle')}
           </p>
         </div>
         <div className="card-content">
@@ -154,7 +158,9 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
                 <span>{drink.name}</span>
                 {drink.volumeMl > 0 && (
                   <span className="text-sm opacity-70">
-                    {stdDrinks(drink.volumeMl, drink.abvPct).toFixed(1)} std
+                    {t('quickActions.quickLog.standardDrinks', {
+                      count: stdDrinks(drink.volumeMl, drink.abvPct).toFixed(1)
+                    })}
                   </span>
                 )}
               </Button>
@@ -170,10 +176,10 @@ export default function QuickActions({ drinks, goals, onAddDrink, onOpenSettings
             <StarIcon />
           </div>
           <h3 className="font-semibold mb-2">
-            {getMotivationalMessage(currentStreak, isAlcoholFree)}
+            {getMotivationalMessage(t, currentStreak, isAlcoholFree)}
           </h3>
           <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            {getMotivationalSubtext(currentStreak, todayStd, goals.dailyCap)}
+            {getMotivationalSubtext(t, todayStd, goals.dailyCap)}
           </p>
         </div>
       </div>
@@ -208,29 +214,29 @@ function CloseIcon() {
 }
 
 // Helper functions
-function getMotivationalMessage(streak: number, isAlcoholFree: boolean): string {
+function getMotivationalMessage(t: Translator, streak: number, isAlcoholFree: boolean): string {
   if (isAlcoholFree) {
-    if (streak >= 30) return "Amazing month-long streak! 🏆";
-    if (streak >= 7) return "Week-long streak going strong! 💪";
-    if (streak >= 3) return "Building momentum! 🚀";
-    if (streak >= 1) return "Another alcohol-free day! ⭐";
-    return "Starting fresh today! 🌅";
+    if (streak >= 30) return t('quickActions.motivation.amazingMonth');
+    if (streak >= 7) return t('quickActions.motivation.weekStrong');
+    if (streak >= 3) return t('quickActions.motivation.buildingMomentum');
+    if (streak >= 1) return t('quickActions.motivation.anotherDay');
+    return t('quickActions.motivation.startingFresh');
   }
 
-  return "Every step counts! 🌟";
+  return t('quickActions.motivation.everyStep');
 }
 
-function getMotivationalSubtext(streak: number, todayStd: number, dailyCap: number): string {
+function getMotivationalSubtext(t: Translator, todayStd: number, dailyCap: number): string {
   if (todayStd === 0) {
-    return "Keep going! Each alcohol-free day builds your strength and resilience.";
+    return t('quickActions.motivationSubtext.alcoholFree');
   }
-  
+
   if (todayStd >= dailyCap) {
-    return "You&apos;ve reached your limit for today. Tomorrow is a new opportunity.";
+    return t('quickActions.motivationSubtext.limitReached');
   }
-  
+
   const remaining = dailyCap - todayStd;
-  return `You have ${remaining.toFixed(1)} drinks remaining in today's limit.`;
+  return t('quickActions.motivationSubtext.remaining', { remaining: remaining.toFixed(1) });
 }
 
 // Icon components

--- a/src/features/insights/__tests__/InsightsTranslations.test.tsx
+++ b/src/features/insights/__tests__/InsightsTranslations.test.tsx
@@ -21,14 +21,26 @@ vi.mock('../../mood/MoodTracker', () => ({
   default: () => <div data-testid="mood-tracker" />
 }));
 
-const dictionaries = { en, es } as const;
+type TranslationDict = { [key: string]: string | TranslationDict };
 
-function resolve(dict: any, key: string): string | undefined {
+const dictionaries: Record<Lang, TranslationDict> = {
+  en: en as TranslationDict,
+  es: es as TranslationDict
+};
+
+function resolve(dict: TranslationDict | undefined, key: string): string | undefined {
+  if (!dict) return undefined;
+
+  if (Object.prototype.hasOwnProperty.call(dict, key)) {
+    const direct = dict[key];
+    return typeof direct === 'string' ? direct : undefined;
+  }
+
   const parts = key.split('.');
-  let current: any = dict;
+  let current: string | TranslationDict | undefined = dict;
   for (const part of parts) {
-    if (current && typeof current === 'object' && part in current) {
-      current = current[part];
+    if (current && typeof current === 'object' && Object.prototype.hasOwnProperty.call(current, part)) {
+      current = (current as TranslationDict)[part];
     } else {
       return undefined;
     }

--- a/src/features/insights/__tests__/InsightsTranslations.test.tsx
+++ b/src/features/insights/__tests__/InsightsTranslations.test.tsx
@@ -131,6 +131,12 @@ describe('insights components translations', () => {
       expect(screen.getByText(translate(lang, 'quickActions.title'))).toBeInTheDocument();
       expect(screen.queryByText('quickActions.title')).not.toBeInTheDocument();
 
+      const todayProgress = translate(lang, 'quickActions.todayDrinksProgress', {
+        consumed: '0.0',
+        limit: sampleGoals.dailyCap,
+      });
+      expect(screen.getByText(todayProgress)).toBeInTheDocument();
+
       expect(screen.getByText(translate(lang, 'smartRecommendations.subtitle'))).toBeInTheDocument();
 
       const nextText = translate(lang, 'progressVisualization.nextMilestone', { days: nextMilestone });

--- a/src/features/insights/__tests__/InsightsTranslations.test.tsx
+++ b/src/features/insights/__tests__/InsightsTranslations.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import QuickActions from '../QuickActions';
+import SmartRecommendations from '../SmartRecommendations';
+import ProgressVisualization from '../ProgressVisualization';
+import { LanguageContext, type Lang, type TranslationValues } from '../../../i18n';
+import en from '../../../locales/en.json';
+import es from '../../../locales/es.json';
+import type { Drink } from '../../drinks/DrinkForm';
+import type { Goals } from '../../../types/common';
+import { getCurrentStreak } from '../lib';
+
+vi.mock('../../analytics/analytics', () => ({
+  useAnalytics: () => ({
+    trackFeatureUsage: vi.fn()
+  })
+}));
+
+vi.mock('../../mood/MoodTracker', () => ({
+  default: () => <div data-testid="mood-tracker" />
+}));
+
+const dictionaries = { en, es } as const;
+
+function resolve(dict: any, key: string): string | undefined {
+  const parts = key.split('.');
+  let current: any = dict;
+  for (const part of parts) {
+    if (current && typeof current === 'object' && part in current) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof current === 'string' ? current : undefined;
+}
+
+function interpolate(template: string, vars?: TranslationValues): string {
+  if (!vars) return template;
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, name) => {
+    if (Object.prototype.hasOwnProperty.call(vars, name)) {
+      return String(vars[name]);
+    }
+    return '';
+  });
+}
+
+function translate(lang: Lang, key: string, vars?: TranslationValues): string {
+  const template = resolve(dictionaries[lang], key) ?? resolve(dictionaries.en, key) ?? key;
+  return interpolate(template, vars);
+}
+
+function renderWithLang(ui: React.ReactElement, lang: Lang) {
+  const t = (key: string, vars?: TranslationValues) => translate(lang, key, vars);
+  return render(
+    <LanguageContext.Provider value={{ lang, setLang: () => {}, t }}>
+      {ui}
+    </LanguageContext.Provider>
+  );
+}
+
+const dayMs = 24 * 60 * 60 * 1000;
+const now = Date.now();
+
+const sampleDrinks: Drink[] = [
+  {
+    volumeMl: 355,
+    abvPct: 5,
+    intention: 'social',
+    craving: 4,
+    halt: ['hungry'],
+    alt: '',
+    ts: now - 2 * dayMs
+  },
+  {
+    volumeMl: 150,
+    abvPct: 12,
+    intention: 'social',
+    craving: 7,
+    halt: ['lonely'],
+    alt: '',
+    ts: now - 10 * dayMs
+  }
+];
+
+const sampleGoals: Goals = {
+  dailyCap: 3,
+  weeklyGoal: 12,
+  pricePerStd: 5,
+  baselineMonthlySpend: 120
+};
+
+const currentStreak = getCurrentStreak(sampleDrinks);
+const milestones = [1, 3, 7, 14, 21, 30, 60, 90, 180, 365];
+const nextMilestone = milestones.find(m => m > currentStreak) ?? currentStreak + 30;
+
+function TestInsights() {
+  return (
+    <>
+      <QuickActions
+        drinks={sampleDrinks}
+        goals={sampleGoals}
+        onAddDrink={() => {}}
+        onOpenSettings={() => {}}
+        onOpenStats={() => {}}
+      />
+      <SmartRecommendations drinks={sampleDrinks} goals={sampleGoals} />
+      <ProgressVisualization drinks={sampleDrinks} goals={sampleGoals} />
+    </>
+  );
+}
+
+describe('insights components translations', () => {
+  (['en', 'es'] as Lang[]).forEach(lang => {
+    test(`renders localized text for ${lang}`, () => {
+      renderWithLang(<TestInsights />, lang);
+
+      expect(screen.getByText(translate(lang, 'quickActions.title'))).toBeInTheDocument();
+      expect(screen.queryByText('quickActions.title')).not.toBeInTheDocument();
+
+      expect(screen.getByText(translate(lang, 'smartRecommendations.subtitle'))).toBeInTheDocument();
+
+      const nextText = translate(lang, 'progressVisualization.nextMilestone', { days: nextMilestone });
+      expect(screen.getByText(nextText)).toBeInTheDocument();
+
+      const daysToGo = translate(lang, 'progressVisualization.daysToGo', {
+        count: nextMilestone - currentStreak
+      });
+      expect(screen.getByText(daysToGo)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -21,15 +21,22 @@ function interpolate(template: string, vars?: TranslationValues): string {
 
 function resolve(dictionary: Dictionary | undefined, key: string): string | undefined {
   if (!dictionary) return undefined;
+
+  if (Object.prototype.hasOwnProperty.call(dictionary, key)) {
+    const direct = dictionary[key];
+    return typeof direct === 'string' ? direct : undefined;
+  }
+
   const parts = key.split('.');
   let current: string | Dictionary | undefined = dictionary;
   for (const part of parts) {
-    if (current && typeof current === 'object' && part in current) {
-      current = current[part] as string | Dictionary;
+    if (current && typeof current === 'object' && Object.prototype.hasOwnProperty.call(current, part)) {
+      current = (current as Dictionary)[part] as string | Dictionary;
     } else {
       return undefined;
     }
   }
+
   return typeof current === 'string' ? current : undefined;
 }
 

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -4,8 +4,34 @@ import en from './locales/en.json';
 
 export type Lang = 'en' | 'es';
 
-type Dictionary = Record<string, string>;
+type Dictionary = Record<string, string | Dictionary>;
 export const dictionaries: Partial<Record<Lang, Dictionary>> = { en: en as Dictionary };
+
+export type TranslationValues = Record<string, string | number>;
+
+function interpolate(template: string, vars?: TranslationValues): string {
+  if (!vars) return template;
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => {
+    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+      return String(vars[key]);
+    }
+    return '';
+  });
+}
+
+function resolve(dictionary: Dictionary | undefined, key: string): string | undefined {
+  if (!dictionary) return undefined;
+  const parts = key.split('.');
+  let current: string | Dictionary | undefined = dictionary;
+  for (const part of parts) {
+    if (current && typeof current === 'object' && part in current) {
+      current = current[part] as string | Dictionary;
+    } else {
+      return undefined;
+    }
+  }
+  return typeof current === 'string' ? current : undefined;
+}
 
 export async function loadLocale(lng: Lang) {
   if (dictionaries[lng]) return;
@@ -13,14 +39,17 @@ export async function loadLocale(lng: Lang) {
   dictionaries[lng] = (res.default || res) as Dictionary;
 }
 
-const LanguageContext = createContext<{
+export const LanguageContext = createContext<{
   lang: Lang;
   setLang: (l: Lang) => void;
-  t: (k: string) => string;
+  t: (k: string, vars?: TranslationValues) => string;
 }>({
   lang: 'en',
   setLang: () => {},
-  t: (k: string) => (dictionaries['en']?.[k] || k),
+  t: (k: string, vars?: TranslationValues) => {
+    const template = resolve(dictionaries['en'], k) ?? k;
+    return interpolate(template, vars);
+  },
 });
 
 export async function loadInitialLang(): Promise<Lang> {
@@ -69,7 +98,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const t = (key: string) => (dictionaries[lang] ?? dictionaries['en'])?.[key] ?? key;
+  const t = (key: string, vars?: TranslationValues) => {
+    const template = resolve(dictionaries[lang], key) ?? resolve(dictionaries['en'], key) ?? key;
+    return interpolate(template, vars);
+  };
 
   return (
     <LanguageContext.Provider value={{ lang, setLang, t }}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,5 +112,114 @@
   "history.deleted": "Entry deleted",
   "toast.undo": "Undo",
   "reminder.prompt": "Reminder: log your day?",
-  "reminder.log": "Log now"
+  "reminder.log": "Log now",
+  "quickActions": {
+    "daysAlcoholFreeLabel": "Days alcohol-free",
+    "todayDrinksLabel": "Today's drinks",
+    "title": "Quick Actions",
+    "actions": {
+      "moodCheckIn": "Mood Check-In",
+      "viewProgress": "View Progress",
+      "settings": "Settings",
+      "afToday": "AF Today!",
+      "logDrink": "Log Drink"
+    },
+    "quickLog": {
+      "title": "Quick Log",
+      "subtitle": "Tap to log common drinks",
+      "standardDrinks": "{{count}} std"
+    },
+    "drinks": {
+      "beer": "Beer ({{volume}}ml, {{abv}}%)",
+      "wine": "Wine ({{volume}}ml, {{abv}}%)",
+      "cocktail": "Cocktail ({{volume}}ml, {{abv}}%)",
+      "custom": "Custom Entry"
+    },
+    "motivation": {
+      "amazingMonth": "Amazing month-long streak! 🏆",
+      "weekStrong": "Week-long streak going strong! 💪",
+      "buildingMomentum": "Building momentum! 🚀",
+      "anotherDay": "Another alcohol-free day! ⭐",
+      "startingFresh": "Starting fresh today! 🌅",
+      "everyStep": "Every step counts! 🌟"
+    },
+    "motivationSubtext": {
+      "alcoholFree": "Keep going! Each alcohol-free day builds your strength and resilience.",
+      "limitReached": "You've reached your limit for today. Tomorrow is a new opportunity.",
+      "remaining": "You have {{remaining}} drinks remaining in today's limit."
+    }
+  },
+  "smartRecommendations": {
+    "title": "Smart Recommendations",
+    "subtitle": "Personalized suggestions based on your patterns",
+    "emptyState": "Great job! No urgent recommendations right now. Keep up the good work!",
+    "approachingDailyLimit": {
+      "title": "Approaching Daily Limit",
+      "description": "You've consumed {{consumed}} of your {{limit}} daily limit. Consider switching to alcohol-free alternatives for the rest of today."
+    },
+    "dailyLimitReached": {
+      "title": "Daily Limit Reached",
+      "description": "You've reached your daily limit. Taking a break now will help you stay on track with your goals."
+    },
+    "weekendStrategy": {
+      "title": "Weekend Strategy Needed",
+      "description": "You tend to drink more on weekends. Consider planning alcohol-free activities or setting a specific weekend limit.",
+      "action": "Set Weekend Goal"
+    },
+    "cravingManagement": {
+      "title": "Craving Management Tips",
+      "description": "You've experienced high cravings recently. Try the 10-minute rule: wait 10 minutes before drinking and engage in a different activity."
+    },
+    "keepStreak": {
+      "title": "Keep Your Streak Going!",
+      "description": "You're {{count}} days alcohol-free. You're doing great! Each day gets easier."
+    },
+    "alternativeActivities": {
+      "title": "Try Alternative Activities",
+      "description": "Consider planning enjoyable alternatives when you feel like drinking: go for a walk, call a friend, or try a new hobby."
+    },
+    "budgetAlert": {
+      "title": "Budget Alert",
+      "description": "You've spent ${{spend}} on alcohol this month, which is over your ${{budget}} budget."
+    },
+    "halt": {
+      "hungry": {
+        "title": "Manage Hunger-Triggered Drinking",
+        "description": "Keep healthy snacks ready and eat regular meals. Low blood sugar can trigger alcohol cravings."
+      },
+      "angry": {
+        "title": "Channel Your Anger Differently",
+        "description": "Try physical exercise, deep breathing, or journaling when you feel angry instead of reaching for alcohol."
+      },
+      "lonely": {
+        "title": "Combat Loneliness Proactively",
+        "description": "Schedule regular social activities or video calls with friends. Loneliness is a common drinking trigger."
+      },
+      "tired": {
+        "title": "Address Fatigue First",
+        "description": "Prioritize sleep hygiene and rest. Being tired makes it harder to resist cravings."
+      }
+    }
+  },
+  "progressVisualization": {
+    "goalProgress": "Goal Progress",
+    "dailyLimit": "Daily Limit",
+    "dailyRemaining": "{{count}} drinks remaining",
+    "dailyExceeded": "Exceeded by {{percent}}%",
+    "weeklyGoal": "Weekly Goal",
+    "weeklyRemaining": "{{count}} drinks remaining this week",
+    "weeklyExceeded": "Exceeded by {{percent}}%",
+    "streakMilestone": "Streak Milestone",
+    "daysAlcoholFree": "Days alcohol-free",
+    "nextMilestone": "Next milestone: {{days}} days",
+    "daysToGo": "{{count}} days to go!",
+    "monthlySpending": "Monthly Spending",
+    "spentThisMonth": "Spent this month",
+    "potentialSavings": "Potential savings",
+    "budgetUsage": "Budget usage",
+    "healthInsights": "Health Insights",
+    "afDaysThisMonth": "AF days this month",
+    "avgCravingLevel": "Avg. craving level",
+    "overallTrend": "Overall trend"
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,7 @@
   "quickActions": {
     "daysAlcoholFreeLabel": "Days alcohol-free",
     "todayDrinksLabel": "Today's drinks",
+    "todayDrinksProgress": "{{consumed}} / {{limit}}",
     "title": "Quick Actions",
     "actions": {
       "moodCheckIn": "Mood Check-In",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -116,6 +116,7 @@
   "quickActions": {
     "daysAlcoholFreeLabel": "Días sin alcohol",
     "todayDrinksLabel": "Bebidas de hoy",
+    "todayDrinksProgress": "{{consumed}} / {{limit}}",
     "title": "Acciones rápidas",
     "actions": {
       "moodCheckIn": "Revisión de ánimo",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -112,5 +112,114 @@
   "history.deleted": "Entrada eliminada",
   "toast.undo": "Deshacer",
   "reminder.prompt": "¿Registrar tu día?",
-  "reminder.log": "Registrar ahora"
+  "reminder.log": "Registrar ahora",
+  "quickActions": {
+    "daysAlcoholFreeLabel": "Días sin alcohol",
+    "todayDrinksLabel": "Bebidas de hoy",
+    "title": "Acciones rápidas",
+    "actions": {
+      "moodCheckIn": "Revisión de ánimo",
+      "viewProgress": "Ver progreso",
+      "settings": "Configuración",
+      "afToday": "¡Sin alcohol hoy!",
+      "logDrink": "Registrar bebida"
+    },
+    "quickLog": {
+      "title": "Registro rápido",
+      "subtitle": "Toca para registrar bebidas comunes",
+      "standardDrinks": "{{count}} beb est."
+    },
+    "drinks": {
+      "beer": "Cerveza ({{volume}}ml, {{abv}}%)",
+      "wine": "Vino ({{volume}}ml, {{abv}}%)",
+      "cocktail": "Coctel ({{volume}}ml, {{abv}}%)",
+      "custom": "Entrada personalizada"
+    },
+    "motivation": {
+      "amazingMonth": "¡Impresionante racha de un mes! 🏆",
+      "weekStrong": "¡Racha de una semana en marcha! 💪",
+      "buildingMomentum": "¡Generando impulso! 🚀",
+      "anotherDay": "¡Otro día sin alcohol! ⭐",
+      "startingFresh": "¡Comenzando fresco hoy! 🌅",
+      "everyStep": "¡Cada paso cuenta! 🌟"
+    },
+    "motivationSubtext": {
+      "alcoholFree": "¡Sigue así! Cada día sin alcohol fortalece tu resistencia.",
+      "limitReached": "Has llegado a tu límite hoy. Mañana es una nueva oportunidad.",
+      "remaining": "Te quedan {{remaining}} bebidas dentro del límite de hoy."
+    }
+  },
+  "smartRecommendations": {
+    "title": "Recomendaciones inteligentes",
+    "subtitle": "Sugerencias personalizadas según tus patrones",
+    "emptyState": "¡Buen trabajo! No hay recomendaciones urgentes ahora. ¡Sigue así!",
+    "approachingDailyLimit": {
+      "title": "Acercándote al límite diario",
+      "description": "Has consumido {{consumed}} de tu límite diario de {{limit}}. Considera opciones sin alcohol para el resto del día."
+    },
+    "dailyLimitReached": {
+      "title": "Límite diario alcanzado",
+      "description": "Has alcanzado tu límite diario. Tomar un descanso ahora te ayudará a mantener tus metas."
+    },
+    "weekendStrategy": {
+      "title": "Se necesita estrategia para el fin de semana",
+      "description": "Sueles beber más los fines de semana. Planea actividades sin alcohol o fija un límite específico.",
+      "action": "Definir meta de fin de semana"
+    },
+    "cravingManagement": {
+      "title": "Consejos para manejar las ansias",
+      "description": "Has tenido ansias altas recientemente. Prueba la regla de los 10 minutos: espera y realiza otra actividad."
+    },
+    "keepStreak": {
+      "title": "¡Mantén tu racha!",
+      "description": "Llevas {{count}} días sin alcohol. ¡Lo haces muy bien! Cada día es más fácil."
+    },
+    "alternativeActivities": {
+      "title": "Prueba actividades alternativas",
+      "description": "Planea alternativas agradables cuando tengas ganas de beber: caminar, llamar a un amigo o probar un pasatiempo."
+    },
+    "budgetAlert": {
+      "title": "Alerta de presupuesto",
+      "description": "Has gastado ${{spend}} en alcohol este mes, lo que supera tu presupuesto de ${{budget}}."
+    },
+    "halt": {
+      "hungry": {
+        "title": "Gestiona la bebida por hambre",
+        "description": "Ten bocadillos saludables y come regularmente. El azúcar baja puede provocar ansias de alcohol."
+      },
+      "angry": {
+        "title": "Canaliza la ira de otra forma",
+        "description": "Prueba ejercicio, respiración profunda o escribir cuando estés enojado en vez de beber."
+      },
+      "lonely": {
+        "title": "Combate la soledad de forma proactiva",
+        "description": "Programa actividades sociales o videollamadas frecuentes. La soledad es un disparador común."
+      },
+      "tired": {
+        "title": "Atiende el cansancio primero",
+        "description": "Prioriza el descanso y la higiene del sueño. Estar cansado dificulta resistir las ansias."
+      }
+    }
+  },
+  "progressVisualization": {
+    "goalProgress": "Progreso de la meta",
+    "dailyLimit": "Límite diario",
+    "dailyRemaining": "Quedan {{count}} bebidas",
+    "dailyExceeded": "Excedido en {{percent}}%",
+    "weeklyGoal": "Meta semanal",
+    "weeklyRemaining": "Quedan {{count}} bebidas esta semana",
+    "weeklyExceeded": "Excedido en {{percent}}%",
+    "streakMilestone": "Hito de racha",
+    "daysAlcoholFree": "Días sin alcohol",
+    "nextMilestone": "Próximo hito: {{days}} días",
+    "daysToGo": "¡Faltan {{count}} días!",
+    "monthlySpending": "Gasto mensual",
+    "spentThisMonth": "Gastado este mes",
+    "potentialSavings": "Ahorro potencial",
+    "budgetUsage": "Uso del presupuesto",
+    "healthInsights": "Información de salud",
+    "afDaysThisMonth": "Días sin alcohol este mes",
+    "avgCravingLevel": "Nivel promedio de ansia",
+    "overallTrend": "Tendencia general"
+  }
 }


### PR DESCRIPTION
## Summary
- localize QuickActions, SmartRecommendations, and ProgressVisualization by using the shared i18n hook
- extend the translation helper for nested keys and add new English and Spanish strings for insights features
- add a vitest smoke test that renders the insights components in English and Spanish to confirm localized output

## Testing
- npm test -- src/features/insights/__tests__/InsightsTranslations.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68daf3f835b483259d96188b913ff65e